### PR TITLE
Remove extra space on Bagel.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [Appetit](https://github.com/Glatek/bun-appetit) - Create universal web applications following the PRPL pattern, with web components.
 - [Colston.js](https://github.com/ajimae/colstonjs) - Fast, lightweight and zero dependency framework for bunjs 🚀.
 - [nbit](https://github.com/sstur/nbit) - A nano-sized, zero-dependency, strongly-typed web framework for Bun.
-- [Bagel.js] (https://github.com/kakengloh/bagel) - Tiny and expressive web framework for Bun, inspired by Express.
+- [Bagel.js](https://github.com/kakengloh/bagel) - Tiny and expressive web framework for Bun, inspired by Express.
 
 ### Libraries
 


### PR DESCRIPTION
Apologies for the extra spacing between the text and hyperlink