### PR TITLE
docs: change url of setup-bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [sublime-bun](https://github.com/alexkuz/sublime-bun) - Bun binary files viewer and other Bun-related stuff for Sublime Text editor.
 - [Shumai](https://github.com/AltriusRS/Shumai) - A delicious new outlook on command line argument handling with Bun.
 - [asdf-bun](https://github.com/cometkim/asdf-bun) - asdf version manager plugin for installing Bun.
-- [setup-bun](https://github.com/xHyroM/setup-bun) - Set up your GitHub Actions workflow with a specific version of Bun.
+- [setup-bun](https://github.com/oven-sh/setup-bun) - Set up your GitHub Actions workflow with a specific version of Bun.
 - [action-setup-bun](https://github.com/antongolub/action-setup-bun) - Setup GitHub Actions workflow with a specific version of Bun.
 - [bun-discord-bot](https://github.com/MiraBellierr/bun-discord-bot) - Interaction Discord bot written in JS and TS using Bun runtime environment.
 - [bun-discord-bot(serverless)](https://github.com/xHyroM/bun-discord-bot) - Official serverless discord bot for bun discord server.


### PR DESCRIPTION
i transfered [xHyroM/setup-bun](https://github.com/xHyroM/setup-bun) to [oven-sh/setup-bun](https://github.com/oven-sh/setup-bun)