### PR TITLE
Removed buchtajs due to 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [GraphQL Mesh](https://github.com/urigo/graphql-mesh) - Gateway that takes any source API and exposes GraphQL. Runs on Bun, Cloudflare Workers, Deno, and any JS environment. 
 - [buxt](https://github.com/mia-z/buxt) - Lightweight filesystem REST API router written for Bun.
 - [Zarf](https://github.com/zarfjs/zarf) - Fast, Bun-first, Web API framework with full Typescript support.
-- [Stric](https://github.com/bunsvr) - Fast and lightweight web framework for Bun.
-- [Buchta](https://buchtajs.com/) - Full-Stack Framework Powered by Bun.
+- [Stric](https://github.com/bunsvr) - Fast and lightweight web framework for Bun. 
 
 ### Libraries
 


### PR DESCRIPTION
from the project page:

_It has been almost a year since buchta was created, and I had made the decision to discontinue its development. With the introduction vite support in bun, there is no longer a need to maintain buchta. Additionally, the energy required to sustain such a massive project has become overwhelming For me. l am conFident that Vite developers will inevitably benefit from bun's utilities. It has been (almost) a remarkable year of existence. This decision is Final._