### PR TITLE
Add Catonaut

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [react-nostalgia-boilerplate](https://github.com/boilertowns/react-nostalgia-boilerplate)
 - [Bun OpenAI Whisper Microservice with Docker](https://github.com/Illyism/whisper-docker)
 - [DBest Stack](https://github.com/itsyoboieltr/dbest-stack)
+- [Astro + Bun Browser Extension Template](https://github.com/AminoffZ/catonaut)
 
 ## Extensions
 


### PR DESCRIPTION
<img src="https://github.com/AminoffZ/catonaut/blob/main/public/assets/images/icon128.png?raw=true" align="right" width="128" height="128" />

# [Catonaut ](https://github.com/AminoffZ/catonaut)

A browser extension template using Bun and Astro. I have been making extensions for a while and this is definitely my favourite way of doing it so far. The repo is generated from the barebones [bun-browser-extension-builder](https://github.com/AminoffZ/bun-browser-extension-builder) template I created a while back and based on its implementation for [github-repo-size](https://github.com/AminoffZ/github-repo-size).

EDIT: Now a part of [awesome-astro](https://github.com/one-aalam/awesome-astro)!