### PR TITLE
Add ikari Bun's first decorators-based web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [NBit](https://github.com/sstur/nbit) - A zero-dependency, strongly-typed web framework for Bun, Node and Cloudflare workers.
 - [GraphQL Yoga](https://github.com/dotansimha/graphql-yoga) - A fast, fully featured GraphQL Framework that [runs on Bun](https://the-guild.dev/graphql/yoga-server/v3/integrations/integration-with-bun), Cloudflare Workers, Deno, and any JS environment. 
 - [Gamepadzilla](https://github.com/RodrigoDornelles/npm-gamepadzilla/) A plug-and-play gamepad frontend framework for HTML5 mobile games, supporting both virtual and physical joysticks. _No scripting required._
+- [ikari](https://github.com/ikari-js/ikari) Bun's first decorators-based web framework, creates fast and elegant enterprise web applications.
 
 ### Libraries
 


### PR DESCRIPTION
ikari is a web framework that is built on typescript decorators and tries to take advantage of all the performance-oriented innovations of Bun. 
Repository: https://github.com/ikari-js/ikari