### PR TITLE
fix: broken link of the try bun due to repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 ## Boilerplates
 
 - [Bun on Railway - Starter](https://github.com/FarazPatankar/bun-on-railway)
-- [Bun Quick-starter for VS Code Remote - Containers and GitHub Codespaces](https://github.com/alertbox/vscode-remote-try-bun)
+- [Bun on Dev Containers & GitHub Codespaces](https://github.com/alertbox/try-bun)
 - [Create Bun Boilerplates](https://github.com/guocaoyi/create-bun)
 - [React Bun Template for Gitpod](https://github.com/Joshuafrankle/bun-react)
 - [React-Typescript template](https://github.com/anjiboss/react-ts-template-for-bun)


### PR DESCRIPTION
this changeset is to fix the broken link of the `try-bun` under the boilerplate section. the ownership of devcontainers-try-bun has been transferred to @alertbox org and then renamed appropriately.

- fix the url for the quick-starter project template
- improve title wording to match the repo