### PR TITLE
docs: add dev containers feature to setup bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [Discall](https://github.com/Discall-Development/Discall) - A async functional discord API wrapper written in bun.
 - [bun-doc](https://github.com/William-McGonagle/bun-doc) - A procedural documentation and website generator written in Bun.
 - [VS Code Bun extension](https://marketplace.visualstudio.com/items?itemName=oven.bun-vscode) - VS Code extension to execute JavaScript .js file or TypeScript .ts file by Bun.
+- [Setup Bun in Dev Containers](https://github.com/alertbox/feature-setup-bun) - Set up your dev containers with a specific version of Bun.
 
 ## Community
 


### PR DESCRIPTION
[try-bun](https://github.com/alertbox/try-bun#readme-ov-file) dev container template repo uses this [feature-setup-bun](https://github/alertbox/feature-setup-bun) dev container feature to download, install, and set up bun.