### PR TITLE
Add bunway (framework) and hitlimit (rate limiter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [Brisa](https://github.com/brisa-build/brisa) A full-stack web framework with Server Actions and Web Components with JSX + signals
 - [Mantou]([link](https://github.com/kao-xiang/mantou)) - A Fullstack React Framework with auto generated documentation.
 - [Blade](https://github.com/ronin-co/blade) — Build instant web apps with React.
-- [bunway](https://github.com/JointOps/bunway) - Express-compatible Bun web framework with batteries included: routing, CORS, sessions, auth, WebSockets and more — actively growing.
+- [bunway](https://github.com/JointOps/bunway) - Express-compatible Bun web framework with routing, CORS, sessions, auth, and WebSockets.
 
 ### Libraries
 
@@ -107,7 +107,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [bun-promptx](https://github.com/wobsoriano/bun-promptx) - Terminal prompt library based on bubbles via bun:ffi.
 - [blipgloss](https://github.com/wobsoriano/blipgloss) - Style definitions for nice terminal layouts 👄.
 - [Orama](https://github.com/oramasearch/orama) - 🌌 Fast, in-memory, typo-tolerant, full-text search engine written in TypeScript.
-- [hitlimit-bun](https://github.com/JointOps/hitlimit-monorepo) - High-performance rate limiter for Bun and Node.js with 8.3M+ ops/sec, 6 storage backends, and support for Bun.serve, Express, Elysia and NestJS — more adapters coming.
+- [hitlimit-bun](https://github.com/JointOps/hitlimit-monorepo) - High-performance rate limiter for Bun and Node.js with 6 storage backends and support for Bun.serve, Express, Elysia, and NestJS.
 - [bnx](https://github.com/wobsoriano/bnx) - zx inspired shell for Bun/Node.
 - [bun-aws-lambda](https://github.com/Jarred-Sumner/bun-aws-lambda) - Hacky attempt to get bun to run on AWS Lambda
 - [postgres-bun](https://github.com/lawrencecchen/postgres-bun) - fast postgres bindings for bun runtime (libpq ffi)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [Brisa](https://github.com/brisa-build/brisa) A full-stack web framework with Server Actions and Web Components with JSX + signals
 - [Mantou]([link](https://github.com/kao-xiang/mantou)) - A Fullstack React Framework with auto generated documentation.
 - [Blade](https://github.com/ronin-co/blade) — Build instant web apps with React.
+- [bunway](https://github.com/JointOps/bunway) - Express-compatible Bun web framework with batteries included: routing, CORS, sessions, auth, WebSockets and more — actively growing.
 
 ### Libraries
 
@@ -106,6 +107,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [bun-promptx](https://github.com/wobsoriano/bun-promptx) - Terminal prompt library based on bubbles via bun:ffi.
 - [blipgloss](https://github.com/wobsoriano/blipgloss) - Style definitions for nice terminal layouts 👄.
 - [Orama](https://github.com/oramasearch/orama) - 🌌 Fast, in-memory, typo-tolerant, full-text search engine written in TypeScript.
+- [hitlimit-bun](https://github.com/JointOps/hitlimit-monorepo) - High-performance rate limiter for Bun and Node.js with 8.3M+ ops/sec, 6 storage backends, and support for Bun.serve, Express, Elysia and NestJS — more adapters coming.
 - [bnx](https://github.com/wobsoriano/bnx) - zx inspired shell for Bun/Node.
 - [bun-aws-lambda](https://github.com/Jarred-Sumner/bun-aws-lambda) - Hacky attempt to get bun to run on AWS Lambda
 - [postgres-bun](https://github.com/lawrencecchen/postgres-bun) - fast postgres bindings for bun runtime (libpq ffi)


### PR DESCRIPTION
Two production-ready, MIT-licensed packages from JointOps.

- **bunway** — Express-compatible Bun framework. Same app.get/app.post API, runs on Bun's native HTTP server. Batteries included out of the box. Docs: https://bunway.jointops.dev
- **hitlimit-bun** — Rate limiter for Bun and Node.js. 8.3M+ ops/sec (Bun, 10K IPs), 6 storage backends (Memory, SQLite, Redis, Valkey, DragonflyDB, Postgres), works with Bun.serve/Express/Elysia/NestJS. Docs: https://hitlimit.jointops.dev