### PR TITLE
Add Bun Sticky to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [bunbot](https://github.com/wobsoriano/bunbot) - Native cross-platform GUI automation for the Bun runtime. Supports Mac and Windows for now.
 - [Discall](https://github.com/Discall-Development/Discall) - A async functional discord API wrapper written in bun.
 - [bun-doc](https://github.com/William-McGonagle/bun-doc) - A procedural documentation and website generator written in Bun.
-- [Bun Sticky](https://github.com/Wolfe-Jam/bun-sticky-faf) - FAF scoring for Bun. Zero-dependency Mk4 WASM kernel for instant AI-readiness project context scoring.
+- [Bun Sticky](https://github.com/Wolfe-Jam/bun-sticky-faf) - Project context scoring for Bun. Mk4 WASM kernel, zero dependencies, 369 tests.
 - [VS Code Bun extension](https://marketplace.visualstudio.com/items?itemName=oven.bun-vscode) - VS Code extension to execute JavaScript .js file or TypeScript .ts file by Bun.
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [bunbot](https://github.com/wobsoriano/bunbot) - Native cross-platform GUI automation for the Bun runtime. Supports Mac and Windows for now.
 - [Discall](https://github.com/Discall-Development/Discall) - A async functional discord API wrapper written in bun.
 - [bun-doc](https://github.com/William-McGonagle/bun-doc) - A procedural documentation and website generator written in Bun.
+- [Bun Sticky](https://github.com/Wolfe-Jam/bun-sticky-faf) - FAF scoring for Bun. Zero-dependency Mk4 WASM kernel for instant AI-readiness project context scoring.
 - [VS Code Bun extension](https://marketplace.visualstudio.com/items?itemName=oven.bun-vscode) - VS Code extension to execute JavaScript .js file or TypeScript .ts file by Bun.
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [bunbot](https://github.com/wobsoriano/bunbot) - Native cross-platform GUI automation for the Bun runtime. Supports Mac and Windows for now.
 - [Discall](https://github.com/Discall-Development/Discall) - A async functional discord API wrapper written in bun.
 - [bun-doc](https://github.com/William-McGonagle/bun-doc) - A procedural documentation and website generator written in Bun.
-- [Bun Sticky](https://github.com/Wolfe-Jam/bun-sticky-faf) - Project context scoring for Bun. Mk4 WASM kernel, zero dependencies, 369 tests.
+- [Bun Sticky](https://github.com/Wolfe-Jam/bun-sticky-faf) - Project context (.faf) scoring for Bun, zero dependencies.
 - [VS Code Bun extension](https://marketplace.visualstudio.com/items?itemName=oven.bun-vscode) - VS Code extension to execute JavaScript .js file or TypeScript .ts file by Bun.
 
 ## Community


### PR DESCRIPTION
## Add Bun Sticky

- [Bun Sticky](https://github.com/Wolfe-Jam/bun-sticky-faf) - FAF scoring for Bun. Zero-dependency Mk4 WASM kernel for instant AI-readiness project context scoring.

### Details

- **npm**: [bun-sticky](https://www.npmjs.com/package/bun-sticky)
- **Version**: v2.0.0
- **Usage**: `bunx bun-sticky score`
- Zero dependencies, Bun-native
- Embeds 322KB Rust WASM kernel for project context scoring

https://github.com/Wolfe-Jam/bun-sticky-faf