### PR TITLE
Add Routup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [Brisa](https://github.com/brisa-build/brisa) A full-stack web framework with Server Actions and Web Components with JSX + signals
 - [Mantou]([link](https://github.com/kao-xiang/mantou)) - A Fullstack React Framework with auto generated documentation.
 - [Blade](https://github.com/ronin-co/blade) — Build instant web apps with React.
+- [Routup](https://github.com/routup/routup) - Runtime-agnostic HTTP routing framework with return-based handlers and tree-shakeable helpers.
 
 ### Libraries
 


### PR DESCRIPTION
Adds [Routup](https://github.com/routup/routup) — a minimalistic, runtime-agnostic HTTP routing framework with first-class Bun support via Web standard APIs.

- Repo: https://github.com/routup/routup
- Docs: https://routup.net
- npm: https://www.npmjs.com/package/routup

Added under `Extensions → Frameworks`, at the bottom of the section per the contribution guidelines.