### PR TITLE
Articles: add 'Bun in 2026: Ship Your Greenfield SaaS, Skip the Migration'

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package ma
 - [Let's create a next.js app with bun](https://dev.to/ashirbadgudu/lets-create-a-nextjs-app-with-bun-48l6)
 - [Bun: A Complete Overhaul of the JavaScript Ecosystem](https://www.lunasec.io/docs/blog/bun-first-look/)
 - [Server-Side Rendering (SSR) With Bun and React](https://alexkates.dev/server-side-rendering-ssr-with-bun-and-react)
+- [Bun in 2026: Ship Your Greenfield SaaS, Skip the Migration](https://shipkit.davrapps.dev/en/blog/bun-saas-backend-2026)
 
 ## Courses & Books
 


### PR DESCRIPTION
Adds a fact-checked 2026 state-of-Bun article to the Articles section: covers Bun 1.3 built-ins (Bun.SQL, Redis, Bun.serve), the v1.4 Rust rewrite and its canary status, and the documented container-memory case (oven-sh/bun #17723) with sizing guidance for production deploys. Every claim is linked to primary sources.

Disclosure: I wrote it — it runs on our Elysia-on-Bun production stack.